### PR TITLE
Added max length to notes, added char counter.

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,9 @@
         </div>
         <div class="one-half column">
           <label for="notes"></label>
-          <textarea id="notes" name="notes" placeholder="Notes"></textarea>
+          <textarea id="notes" name="notes" placeholder="Notes" maxlength="1000"></textarea>
+          <div id="notesCharCount"></div>
+          <br />
           <button type="button" onclick="logData()">Create Log Entry</button>
 
           <!-- Remove this before release to production

--- a/script.js
+++ b/script.js
@@ -219,4 +219,23 @@ function updateRuntime(firstEntryTime) {
   document.getElementById("totalRuntime").innerText = formattedRuntime;
 }
 
+function initializeNotesCharacterCounter(textareaId, counterId) {
+  const textarea = document.getElementById(textareaId);
+  const charCount = document.getElementById(counterId);
+  const maxLength = textarea.getAttribute('maxlength');
+
+  const updateCharCount = () => {
+    const currentLength = textarea.value.length;
+    charCount.textContent = `${maxLength - currentLength}`;
+  };
+
+  textarea.addEventListener('input', updateCharCount);
+
+  updateCharCount();
+}
+
 displayTotalRuntime();
+
+document.addEventListener('DOMContentLoaded', () => {
+  initializeNotesCharacterCounter('notes', 'notesCharCount');
+});


### PR DESCRIPTION
Adds a maximum length of 1,000 characters to the notes field. Additionally, added a counter that will count down the number of characters still available to the user for easy reference. 

The only reference to max length is in the text area - therefore only one place to change if you want a different value.